### PR TITLE
fix mac unknown non-unicode keyboard layout

### DIFF
--- a/lib/pynput/_util/darwin.py
+++ b/lib/pynput/_util/darwin.py
@@ -76,6 +76,9 @@ class CarbonExtra(object):
     _Carbon.TISCopyCurrentKeyboardInputSource.argtypes = []
     _Carbon.TISCopyCurrentKeyboardInputSource.restype = ctypes.c_void_p
 
+    _Carbon.TISCopyCurrentASCIICapableKeyboardLayoutInputSource.argtypes = []
+    _Carbon.TISCopyCurrentASCIICapableKeyboardLayoutInputSource.restype = ctypes.c_void_p
+
     _Carbon.TISGetInputSourceProperty.argtypes = [
         ctypes.c_void_p, ctypes.c_void_p]
     _Carbon.TISGetInputSourceProperty.restype = ctypes.c_void_p
@@ -99,6 +102,9 @@ class CarbonExtra(object):
     TISCopyCurrentKeyboardInputSource = \
         _Carbon.TISCopyCurrentKeyboardInputSource
 
+    TISCopyCurrentASCIICapableKeyboardLayoutInputSource = \
+        _Carbon.TISCopyCurrentASCIICapableKeyboardLayoutInputSource
+
     kTISPropertyUnicodeKeyLayoutData = ctypes.c_void_p.in_dll(
         _Carbon, 'kTISPropertyUnicodeKeyLayoutData')
 
@@ -120,13 +126,20 @@ def keycode_context():
     """Returns an opaque value representing a context for translating keycodes
     to strings.
     """
-    with _wrapped(CarbonExtra.TISCopyCurrentKeyboardInputSource()) as keyboard:
-        keyboard_type = CarbonExtra.LMGetKbdType()
-        layout = _wrap_value(CarbonExtra.TISGetInputSourceProperty(
-            keyboard,
-            CarbonExtra.kTISPropertyUnicodeKeyLayoutData))
-        layout_data = layout.bytes().tobytes() if layout else None
-        yield (keyboard_type, layout_data)
+    keyboard_type, layout_data = None, None
+    for source in [
+        CarbonExtra.TISCopyCurrentKeyboardInputSource,
+        CarbonExtra.TISCopyCurrentASCIICapableKeyboardLayoutInputSource
+    ]:
+        with _wrapped(source()) as keyboard:
+            keyboard_type = CarbonExtra.LMGetKbdType()
+            layout = _wrap_value(CarbonExtra.TISGetInputSourceProperty(
+                keyboard,
+                CarbonExtra.kTISPropertyUnicodeKeyLayoutData))
+            layout_data = layout.bytes().tobytes() if layout else None
+            if keyboard is not None and layout_data is not None:
+                break
+    yield (keyboard_type, layout_data)
 
 
 def keycode_to_string(context, keycode, modifier_state=0):


### PR DESCRIPTION
According to my research, there are multiple functions we can use to get the input source and keyboard layout([HIToolbox Release Notes for OS X v10.5](https://developer.apple.com/library/content/releasenotes/Carbon/HIToolbox.html)),  `TISCopyCurrentKeyboardInputSource`, `TISCopyCurrentKeyboardLayoutInputSource`, `TISCopyCurrentASCIICapableKeyboardInputSource` and `TISCopyCurrentASCIICapableKeyboardLayoutInputSource`. We can find the detailed comments at [phracker/MacOSX-SDKs](https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.6.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/TextInputSources.h).

And after some study, I think there is no fixed method to choose which one is correct. In many case, they first use one of them, and if the `layout_data` is null, then try another. I tried them one by one, and I found the last three functions has the same memorize addresses(same pointer), so in my pull request, I just use two functions to try, just like other people done.

Reference link:
https://github.com/quicksilver/Quicksilver/blob/a7d6fb26690659a3f75545e97feab1f7c732996c/Quicksilver/Code-External/NDClasses/NDKeyboardLayout.m

https://github.com/davedelong/DDHotKey/commit/d5e6ab5bad050d21d93781a5e4e8c6e60ca449e6

https://github.com/lacasanova/shortcutrecorder/issues/45