### PR TITLE
Fix key presses with xephyr

### DIFF
--- a/lib/pynput/keyboard/_xorg.py
+++ b/lib/pynput/keyboard/_xorg.py
@@ -248,7 +248,7 @@ class Controller(NotifierMixin, _base.Controller):
         """
         with display_manager(self._display) as dm, self.modifiers as modifiers:
             window = dm.get_input_focus().focus
-            window.send_event(event(
+            dm.send_event(window, event(
                 detail=keycode,
                 state=shift_state | self._shift_mask(modifiers),
                 time=0,


### PR DESCRIPTION
Per #37.

This may prove more resilient to API inconsistencies, such as when the focus field is a number instead of a window object.

I'm curious what your thoughts are on this - it seems like this should be unnecessary, yet it fixes my problem :)