### PR TITLE
Xorg keyboard: missing import

### DIFF
--- a/lib/pynput/keyboard/_xorg.py
+++ b/lib/pynput/keyboard/_xorg.py
@@ -33,6 +33,7 @@ import Xlib.ext.xtest
 import Xlib.X
 import Xlib.XK
 import Xlib.protocol
+import Xlib.keysymdef.xkb
 
 from pynput._util import NotifierMixin
 from pynput._util.xorg import (


### PR DESCRIPTION
It seems that the `Xlib.keysymdef.xkb` call at line76 was failing because of that. The error was silenced by the `try…except` block.