### PR TITLE
Add level3_shift special key

### DIFF
--- a/lib/pynput/keyboard/_xorg.py
+++ b/lib/pynput/keyboard/_xorg.py
@@ -88,6 +88,7 @@ class Key(enum.Enum):
     alt_l = KeyCode._from_symbol('Alt_L')
     alt_r = KeyCode._from_symbol('Alt_R')
     alt_gr = KeyCode._from_symbol('Mode_switch')
+    level3_shift = KeyCode._from_symbol('ISO_Level3_Shift')
     backspace = KeyCode._from_symbol('BackSpace')
     caps_lock = KeyCode._from_symbol('Caps_Lock')
     cmd = KeyCode._from_symbol('Super_L')


### PR DESCRIPTION
In a lot of keyboard layouts (See the output of `grep -r ralt_switch  /usr/share/X11/xkb/`), the AltGr is mapped to the ISO_Level3_Shift.
I decided to strip the `ISO_` prefix from the member name. Feel free to integrate it if you like.