### PR TITLE
Modification of the windows keyboard api, to consider pressed keys as direct inputs

### DIFF
--- a/lib/pynput/_util/win32.py
+++ b/lib/pynput/_util/win32.py
@@ -120,6 +120,11 @@ class INPUT(ctypes.Structure):
 
 LPINPUT = ctypes.POINTER(INPUT)
 
+MapVirtualKey = windll.user32.MapVirtualKeyW
+MapVirtualKey.argtypes = (
+    wintypes.UINT,
+    wintypes.UINT)
+
 VkKeyScan = windll.user32.VkKeyScanW
 VkKeyScan.argtypes = (
     wintypes.WCHAR,)

--- a/lib/pynput/keyboard/_win32.py
+++ b/lib/pynput/keyboard/_win32.py
@@ -42,7 +42,8 @@ from pynput._util.win32 import (
     ListenerMixin,
     SendInput,
     SystemHook,
-    VkKeyScan)
+    VkKeyScan,
+    MapVirtualKey)
 from . import _base
 
 
@@ -56,22 +57,30 @@ class KeyCode(_base.KeyCode):
 
         :rtype: dict
         """
+
+        flags = 0
+
         if self.vk:
             vk = self.vk
-            scan = 0
-            flags = 0
-        else:
-            res = VkKeyScan(self.char)
-            if (res >> 8) & 0xFF == 0:
-                vk = res & 0xFF
-                scan = 0
-                flags = 0
+            scan = MapVirtualKey(vk, 0)
+
+        else :
+
+            virtualCode = VkKeyScan(self.char)
+
+            if (virtualCode >> 8) & 0xFF == 0:
+                vk = virtualCode & 0xFF
+                scan = MapVirtualKey(virtualCode, 0)
+
             else:
                 vk = 0
                 scan = ord(self.char)
                 flags = KEYBDINPUT.UNICODE
+
+        flags = (flags | 0) if is_press else (flags | 0x0002) # cf tagKEYBDINPUT structure, dwFlags parameter from the microsoft doc
+
         return dict(
-            dwFlags=flags | (KEYBDINPUT.KEYUP if not is_press else 0),
+            dwFlags=flags,
             wVk=vk,
             wScan=scan)
 


### PR DESCRIPTION
Hello!

I'm proposing a modification of the keyboard part of the windows api, in order to consider pressed keys as direct inputs. This modification allows to use Pynput with many more application, especially softwares using directX (eg video games).

This feature is more and more requested, especially because of the huge development of AI libraries which are relatively easy to use (ex : tensorFlow). Project of creation of bots which interact with games using computer and mouse inputs are flourishing. A good example is PYGTAV on github, for which its initiator even made a nice website with tutorials on how to code such applications.

I've decided to contribute to this project, which I found easy to use and well adapted for that kind of problems. I've minimized my additions as much as I could and tried to make them as clear as possible. I've also spent a day to test for non regression. As no test cases are provided with this project, I can't fully ensure that there aren’t any regression problems at all.

waiting forward to hearing from your feedbacks!


