### PR TITLE
Added VK Media & Volume support for windows

### DIFF
--- a/docs/keyboard-usage.rst
+++ b/docs/keyboard-usage.rst
@@ -56,7 +56,7 @@ Use ``pynput.keyboard.Listener`` like this::
         listener.join()
 
     # ...or, in a non-blocking fashion:
-    listener = mouse.Listener(
+    listener = keyboard.Listener(
         on_press=on_press,
         on_release=on_release)
     listener.start()

--- a/docs/keyboard-usage.rst
+++ b/docs/keyboard-usage.rst
@@ -110,3 +110,15 @@ instance::
             listener.join()
         except MyException as e:
             print('{0} was pressed'.format(e.args[0]))
+
+
+Toggling event listening
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once :method:`pynput.keyboard.Listener.stop` has been called, the listener
+cannot be restarted, since listeners are instances of
+:class:`threading.Thread`.
+
+If your application requires toggling listening events, you must either add an
+internal flag to ignore events when not required, or create a new listener when
+resuming listening.

--- a/docs/mouse-usage.rst
+++ b/docs/mouse-usage.rst
@@ -114,3 +114,14 @@ instance::
             listener.join()
         except MyException as e:
             print('{0} was clicked'.format(e.args[0]))
+
+
+Toggling event listening
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once :method:`pynput.mouse.Listener.stop` has been called, the listener cannot
+be restarted, since listeners are instances of :class:`threading.Thread`.
+
+If your application requires toggling listening events, you must either add an
+internal flag to ignore events when not required, or create a new listener when
+resuming listening.

--- a/lib/pynput/_util/__init__.py
+++ b/lib/pynput/_util/__init__.py
@@ -108,7 +108,12 @@ class AbstractListener(threading.Thread):
     def stop(self):
         """Stops listening for events.
 
-        When this method returns, no more events will be delivered.
+        When this method returns, no more events will be delivered. Once this
+        method has been called, the listener instance cannot be used any more,
+        since a listener is a :class:`threading.Thread`, and once stopped it
+        cannot be restarted.
+
+        To resume listening for event, a new listener must be created.
         """
         if self._running:
             self._running = False

--- a/lib/pynput/keyboard/_base.py
+++ b/lib/pynput/keyboard/_base.py
@@ -625,7 +625,7 @@ class Listener(AbstractListener):
         It will be called with the argument ``(key)``, where ``key`` is a
         :class:`KeyCode`, a :class:`Key` or ``None`` if the key is unknown.
 
-    :param callable on_release: The callback to call when a button is release.
+    :param callable on_release: The callback to call when a button is released.
 
         It will be called with the argument ``(key)``, where ``key`` is a
         :class:`KeyCode`, a :class:`Key` or ``None`` if the key is unknown.

--- a/lib/pynput/keyboard/_win32.py
+++ b/lib/pynput/keyboard/_win32.py
@@ -133,6 +133,13 @@ class Key(enum.Enum):
     print_screen = KeyCode.from_vk(VK.SNAPSHOT)
     scroll_lock = KeyCode.from_vk(VK.SCROLL)
 
+    media_play_pause = KeyCode.from_vk(VK.MEDIA_PLAY_PAUSE)
+    volume_mute = KeyCode.from_vk(VK.VOLUME_MUTE)
+    volume_down = KeyCode.from_vk(VK.VOLUME_DOWN)
+    volume_up = KeyCode.from_vk(VK.VOLUME_UP)
+    media_next = KeyCode.from_vk(VK.MEDIA_NEXT_TRACK)
+    media_previous = KeyCode.from_vk(VK.MEDIA_PREV_TRACK)
+
 
 class Controller(_base.Controller):
     _KeyCode = KeyCode


### PR DESCRIPTION
Added 6 VK key entries to the Key Class. These keys are used to control media on windows.

CODE:
media_play_pause = KeyCode.from_vk(VK.MEDIA_PLAY_PAUSE)
volume_mute = KeyCode.from_vk(VK.VOLUME_MUTE)
volume_down = KeyCode.from_vk(VK.VOLUME_DOWN)
volume_up = KeyCode.from_vk(VK.VOLUME_UP)
media_next = KeyCode.from_vk(VK.MEDIA_NEXT_TRACK)
media_previous = KeyCode.from_vk(VK.MEDIA_PREV_TRACK)