### PR TITLE
Fix symbol input on OSX

### DIFF
--- a/lib/pynput/keyboard/_darwin.py
+++ b/lib/pynput/keyboard/_darwin.py
@@ -47,8 +47,9 @@ class KeyCode(_base.KeyCode):
 
         :return: a *Quartz* event
         """
-        vk = self.vk or mapping.get(self.char, 0)
-        result = Quartz.CGEventCreateKeyboardEvent(None, vk, is_pressed)
+        vk = self.vk or mapping.get(self.char)
+        result = Quartz.CGEventCreateKeyboardEvent(
+                None, 0 if vk is None else vk, is_pressed)
 
         Quartz.CGEventSetFlags(
             result,


### PR DESCRIPTION
Fix #140 .

`vk` may be assigned to `0` here:

https://github.com/moses-palmer/pynput/blob/ff9c569c575ad3e59d25bfea788289b2aa0a1f37/lib/pynput/keyboard/_darwin.py#L50

So the condition needs to be changed.