### PR TITLE
Fixing infinite scrolling if decimal values are used for darwin implementation.

### DIFF
--- a/lib/pynput/mouse/_darwin.py
+++ b/lib/pynput/mouse/_darwin.py
@@ -90,6 +90,8 @@ class Controller(_base.Controller):
                 mouse_button))
 
     def _scroll(self, dx, dy):
+        dx = int( dx )
+        dy = int( dy )
         while dx != 0 or dy != 0:
             xval = 1 if dx > 0 else -1 if dx < 0 else 0
             dx -= xval


### PR DESCRIPTION
mouse.scroll(0, 2.0) for instance could end up scrolling infinitely.

```
scrolling 0 -1.999999999999993
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
scrolling 0 7.105427357601002e-15
scrolling 0 -0.9999999999999929
...
```
