### PR TITLE
update supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,5 +120,10 @@ setuptools.setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Monitoring'])


### PR DESCRIPTION
allow installation on recent python

Should we allow Python 3.x instead?