### PR TITLE
Event.get() to return None on timeout

### DIFF
--- a/lib/pynput/_util/__init__.py
+++ b/lib/pynput/_util/__init__.py
@@ -304,8 +304,12 @@ class Events(object):
             method may block infinitely.
 
         :return: The next event, or ``None`` if the source has been stopped
+            or on timeout
         """
-        event = self._event_queue.get(timeout=timeout)
+        try:
+            event = self._event_queue.get(timeout=timeout)
+        except queue.Empty:
+            return None
         return event if event is not self._sentinel else None
 
     def _event_mapper(self, event):


### PR DESCRIPTION
Created issue #244 for this, will try associating it with this pull request.

On timeout Event.get() throws queue.Empty instead of None as advertised in the method documentation.
This is not ideal as it exposes the user to internal implementation details (using a queue), should better not leak outside.
More important, it is cleaner and simpler to either return the event or None.

Happened with pynput 1.6.8 on Windows 10 - should be the same on other OSes.

The code that triggered it was an attempt to implement the equivalent of getch(). See below.

Fix is trivial, pull request coming soon.
```
def getch(timeout=None):

    from pynput import keyboard
    with keyboard.Events() as events:
        event = events.get(timeout)
        if event is not None and hasattr(event.key, 'char'):
            return event.key.char
        return None
```
Got when called as **getch(5)** and letting it timeout (code changed in the meantime ;)):
```
(base) C:\Users\Adi>C:/Users/Adi/Anaconda3/python.exe "d:/Root/Code/# Interview/play.py"
Option: Traceback (most recent call last):
  File "d:/Root/Code/# Interview/play.py", line 68, in <module>
    res = getch(5)
  File "d:/Root/Code/# Interview/play.py", line 22, in getch
    event = events.get(timeout)
  File "C:\Users\Adi\Anaconda3\lib\site-packages\pynput\_util\__init__.py", line 277, in get
    event = self._event_queue.get(timeout=timeout)
  File "C:\Users\Adi\Anaconda3\lib\queue.py", line 178, in get
    raise Empty
_queue.Empty
```

Thanks.