### PR TITLE
Fix for dead keys, if dead keys with combining not found search witho…

### DIFF
--- a/lib/pynput/keyboard/_base.py
+++ b/lib/pynput/keyboard/_base.py
@@ -49,8 +49,12 @@ class KeyCode(object):
         self.is_dead = is_dead
 
         if self.is_dead:
-            self.combining = unicodedata.lookup(
-                'COMBINING ' + unicodedata.name(self.char))
+            try:
+                self.combining = unicodedata.lookup(
+                    'COMBINING ' + unicodedata.name(self.char))
+            except KeyError:
+                self.combining = unicodedata.lookup(
+                    unicodedata.name(self.char))
             if not self.combining:
                 raise KeyError(char)
         else:


### PR DESCRIPTION
I noticed an issue with the ' key, when I was using your package.
When I saw there where more people having this issue I decided to fix it.

What goes wrong, unicodedata.lookup search for  'COMBINING' + the key in the database.
This goes wrong with the ' key because there is nog COMBINING APOSTROPHE' so this triggers an KeyError.

What I did is that I except this KeyError and then search for the key without 'COMBINING' after this it works fine and the issue is fixed.

Related Issue: https://github.com/moses-palmer/pynput/issues/199