### PR TITLE
Added ability to get screen resolution/size

### DIFF
--- a/lib/pynput/screen/utils.py
+++ b/lib/pynput/screen/utils.py
@@ -1,0 +1,61 @@
+from pynput.mouse import Controller as MouseController
+
+def get_screen_size():
+    """Utility function to get screen resolution"""
+
+    mouse = MouseController()
+
+    width = height = 0
+
+    def _reset_mouse_position():
+        # Move the mouse to the top left of 
+        # the screen
+        mouse.position = (0, 0)
+
+    # Reset mouse position
+    _reset_mouse_position()
+
+    count = 0
+    while 1:
+        count += 1
+        mouse.move(count, 0)
+        
+        # Get the current position of the mouse
+        left = mouse.position[0]
+
+        # If the left doesn't change anymore, then
+        # that's the screen resolution's width
+        if width == left:
+            # Add the last pixel
+            width += 1
+
+            # Reset count for use for height
+            count = 0
+            break
+
+        # On each iteration, assign the left to 
+        # the width
+        width = left
+    
+    # Reset mouse position
+    _reset_mouse_position()
+
+    while 1:
+        count += 1
+        mouse.move(0, count)
+
+        # Get the current position of the mouse
+        right = mouse.position[1]
+
+        # If the right doesn't change anymore, then
+        # that's the screen resolution's height
+        if height == right:
+            # Add the last pixel
+            height += 1
+            break
+
+        # On each iteration, assign the left to 
+        # the width
+        height = right
+
+    return width, height


### PR DESCRIPTION
Hi.

Was looking to add the ability to get the screen size of the current system, as I always have to use another library (`pyautogui`) to do that. Would be nice if `pynput` could have a small utility function that does that. 

Not sure if the PR follows your folder structure, but I really just wanted to show the basic functionality itself, leaving folder logistics for later. So, I added a `screen` module and a `get_screen_size()` function that, essentially, loops through the borders of the screen to get the screen size. 

Let me know what you think.

A simple test:
```
>>> from pynput.screen.utils import get_screen_size
>>> get_screen_size()
(1920, 1080)
```