### PR TITLE
Fix for HotKey false activations with lower modifiers

### DIFF
--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -176,7 +176,7 @@ class HotKey(object):
         :param key: The key being pressed.
         :type key: Key or KeyCode
         """
-        if key in self._keys and key not in self._state:
+        if key not in self._state:
             self._state.add(key)
             if self._state == self._keys:
                 self._on_activate()
@@ -193,7 +193,7 @@ class HotKey(object):
 
 class GlobalHotKeys(Listener):
     """A keyboard listener supporting a number of global hotkeys.
-
+    
     This is a convenience wrapper to simplify registering a number of global
     hotkeys.
 
@@ -202,6 +202,8 @@ class GlobalHotKeys(Listener):
 
     :raises ValueError: if any hotkey description is invalid
     """
+
+    
     def __init__(self, hotkeys, *args, **kwargs):
         self._hotkeys = [
             HotKey(HotKey.parse(key), value)

--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -202,8 +202,6 @@ class GlobalHotKeys(Listener):
 
     :raises ValueError: if any hotkey description is invalid
     """
-
-    
     def __init__(self, hotkeys, *args, **kwargs):
         self._hotkeys = [
             HotKey(HotKey.parse(key), value)

--- a/tests/keyboard_hotkey_tests.py
+++ b/tests/keyboard_hotkey_tests.py
@@ -140,12 +140,15 @@ class KeyboardHotKeyTest(unittest.TestCase):
         q = queue.Queue()
 
         with GlobalHotKeys({
+                '<ctrl>+a': lambda: q.put('x'),
                 '<ctrl>+<shift>+a': lambda: q.put('a'),
                 '<ctrl>+<shift>+b': lambda: q.put('b'),
                 '<ctrl>+<shift>+c': lambda: q.put('c')}):
+            
             notify('Press <ctrl>+<shift>+a')
+            self.assertNotEqual('x', q.get())
             self.assertEqual('a', q.get())
-
+            
             notify('Press <ctrl>+<shift>+b')
             self.assertEqual('b', q.get())
 


### PR DESCRIPTION
If you have multiple hotkeys defined with the same key, but different modifiers you can have false activations. e.g. if we define hotkeys:

```
<ctrl>+a
<shift>+a
<ctrl>+<shift>+a
```

All three will be triggered when pressing ctrl+shift+a. This is due to state being held locally in the hotkey and keys only added to the state if they exist as part of the hotkey combo. 

I've removed the `key in self._keys` check before adding to state as a quick fix, but maintaining state globally may be a better solution. 