### PR TITLE
fix(xorg): Fix media keysym string prefix on Linux

### DIFF
--- a/lib/pynput/keyboard/_xorg.py
+++ b/lib/pynput/keyboard/_xorg.py
@@ -106,11 +106,11 @@ class KeyCode(_base.KeyCode):
         """Creates a media key from a partial name.
 
         :param str name: The name. The actual symbol name will be this string
-            with ``'XF86Audio'`` prepended.
+            with ``'XF86_Audio'`` prepended.
 
         :return: a key code
         """
-        return cls._from_symbol('XF86Audio' + name, **kwargs)
+        return cls._from_symbol('XF86_Audio' + name, **kwargs)
 
 
 # pylint: disable=W0212


### PR DESCRIPTION
With the current prefixing of media keys, it's not possible to emulate key events on Linux. The fix is inspired by https://github.com/openstenoproject/plover/blob/d20167f4da549376af7d978dec5c17b1c4f94d89/plover/oslayer/xkeyboardcontrol.py#L52, where the right prefix, i.e. "XF86_Audio", is used.