### PR TITLE
Don't parse compose lines from dumpkeys (uinput)

### DIFF
--- a/lib/pynput/keyboard/_uinput.py
+++ b/lib/pynput/keyboard/_uinput.py
@@ -253,7 +253,7 @@ class Layout(object):
         result = {}
         for keycode, names in self.KEYCODE_RE.findall(
                 subprocess.check_output(
-                    ['dumpkeys', '--full-table']).decode('utf-8')):
+                    ['dumpkeys', '--full-table', '--keys-only']).decode('utf-8')):
             vk = int(keycode)
             keys = tuple(
                 self._parse(vk, name)


### PR DESCRIPTION
Compose can contain unicode characters.
for example:
compose '�' 'A' to Aring

Reading them with
subprocess.check_output(..).decode('utf-8') leads to:
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 0: invalid start byte`

dumpkeys has a parameter --keys-only, that avoids printing the compose
keys.
More information here:
https://man7.org/linux/man-pages/man1/dumpkeys.1.html

Since only the lines that begin with 'keycode' are used, the usage of
--keys-only is safe.