### PR TITLE
Eagerly import symbols on import instead of resolving at runtime

### DIFF
--- a/lib/pynput/_util/darwin.py
+++ b/lib/pynput/_util/darwin.py
@@ -28,9 +28,15 @@ import ctypes.util
 import six
 
 import objc
-import CoreFoundation
-import HIServices
-import Quartz
+from HIServices import AXIsProcessTrusted
+from CoreFoundation import (
+    CFMachPortCreateRunLoopSource, CFRelease, CFRunLoopAddSource,
+    CFRunLoopGetCurrent, CFRunLoopRunInMode, CFRunLoopStop)
+
+from Quartz import (
+    CGEventTapCreate, CGEventTapEnable, kCFRunLoopDefaultMode,
+    kCFRunLoopDefaultMode, kCFRunLoopRunTimedOut, kCGEventTapOptionDefault,
+    kCGEventTapOptionListenOnly, kCGHeadInsertEventTap, kCGSessionEventTap)
 
 from . import AbstractListener
 
@@ -65,7 +71,7 @@ def _wrapped(value):
     try:
         yield value
     finally:
-        CoreFoundation.CFRelease(wrapped_value)
+        CFRelease(wrapped_value)
 
 
 class CarbonExtra(object):
@@ -193,7 +199,7 @@ class ListenerMixin(object):
     IS_TRUSTED = False
 
     def _run(self):
-        self.IS_TRUSTED = HIServices.AXIsProcessTrusted()
+        self.IS_TRUSTED = AXIsProcessTrusted()
         if not self.IS_TRUSTED:
             self._log.warning(
                 'This process is not trusted! Input event monitoring will not '
@@ -206,23 +212,23 @@ class ListenerMixin(object):
                 self._mark_ready()
                 return
 
-            loop_source = Quartz.CFMachPortCreateRunLoopSource(
+            loop_source = CFMachPortCreateRunLoopSource(
                 None, tap, 0)
-            self._loop = Quartz.CFRunLoopGetCurrent()
+            self._loop = CFRunLoopGetCurrent()
 
-            Quartz.CFRunLoopAddSource(
-                self._loop, loop_source, Quartz.kCFRunLoopDefaultMode)
-            Quartz.CGEventTapEnable(tap, True)
+            CFRunLoopAddSource(
+                self._loop, loop_source, kCFRunLoopDefaultMode)
+            CGEventTapEnable(tap, True)
 
             self._mark_ready()
 
             # pylint: disable=W0702; we want to silence errors
             try:
                 while self.running:
-                    result = Quartz.CFRunLoopRunInMode(
-                        Quartz.kCFRunLoopDefaultMode, 1, False)
+                    result = CFRunLoopRunInMode(
+                        kCFRunLoopDefaultMode, 1, False)
                     try:
-                        if result != Quartz.kCFRunLoopRunTimedOut:
+                        if result != kCFRunLoopRunTimedOut:
                             break
                     except AttributeError:
                         # This happens during teardown of the virtual machine
@@ -241,7 +247,7 @@ class ListenerMixin(object):
         # loop around run loop invocations to terminate and set this event
         try:
             if self._loop is not None:
-                Quartz.CFRunLoopStop(self._loop)
+                CFRunLoopStop(self._loop)
         except AttributeError:
             # The loop may not have been created
             pass
@@ -251,14 +257,14 @@ class ListenerMixin(object):
 
         :return: an event tap
         """
-        return Quartz.CGEventTapCreate(
-            Quartz.kCGSessionEventTap,
-            Quartz.kCGHeadInsertEventTap,
-            Quartz.kCGEventTapOptionListenOnly if (
+        return CGEventTapCreate(
+            kCGSessionEventTap,
+            kCGHeadInsertEventTap,
+            kCGEventTapOptionListenOnly if (
                 True
                 and not self.suppress
                 and self._intercept is None)
-            else Quartz.kCGEventTapOptionDefault,
+            else kCGEventTapOptionDefault,
             self._EVENTS,
             self._handler,
             None)

--- a/lib/pynput/keyboard/_darwin.py
+++ b/lib/pynput/keyboard/_darwin.py
@@ -26,7 +26,14 @@ The keyboard implementation for *macOS*.
 
 import enum
 
-import Quartz
+from AppKit import NSEvent, NSSystemDefined
+from Quartz import (
+    CGEventCreateKeyboardEvent, CGEventGetFlags, CGEventGetIntegerValueField,
+    CGEventGetType, CGEventKeyboardGetUnicodeString, CGEventKeyboardSetUnicodeString,
+    CGEventMaskBit, CGEventPost, CGEventSetFlags, NSSystemDefined,
+    kCGEventFlagMaskAlternate, kCGEventFlagMaskCommand, kCGEventFlagMaskControl,
+    kCGEventFlagMaskShift, kCGEventFlagsChanged, kCGEventKeyDown, kCGEventKeyUp,
+    kCGHIDEventTap, kCGKeyboardEventKeycode)
 
 from pynput._util.darwin import (
     get_unicode_to_keycode_map,
@@ -49,7 +56,7 @@ kSystemDefinedEventMediaKeysSubtype = 8
 
 # We extract this here since the name is very long
 otherEventWithType = getattr(
-        Quartz.NSEvent,
+        NSEvent,
         'otherEventWithType_'
         'location_'
         'modifierFlags_'
@@ -95,7 +102,7 @@ class KeyCode(_base.KeyCode):
         vk = self.vk or mapping.get(self.char)
         if self._is_media:
             result = otherEventWithType(
-                Quartz.NSSystemDefined,
+                NSSystemDefined,
                 (0, 0),
                 0xa00 if is_pressed else 0xb00,
                 0,
@@ -105,26 +112,26 @@ class KeyCode(_base.KeyCode):
                 (self.vk << 16) | ((0xa if is_pressed else 0xb) << 8),
                 -1).CGEvent()
         else:
-            result = Quartz.CGEventCreateKeyboardEvent(
+            result = CGEventCreateKeyboardEvent(
                 None, 0 if vk is None else vk, is_pressed)
 
-        Quartz.CGEventSetFlags(
+        CGEventSetFlags(
             result,
             0
-            | (Quartz.kCGEventFlagMaskAlternate
+            | (kCGEventFlagMaskAlternate
                if Key.alt in modifiers else 0)
 
-            | (Quartz.kCGEventFlagMaskCommand
+            | (kCGEventFlagMaskCommand
                if Key.cmd in modifiers else 0)
 
-            | (Quartz.kCGEventFlagMaskControl
+            | (kCGEventFlagMaskControl
                if Key.ctrl in modifiers else 0)
 
-            | (Quartz.kCGEventFlagMaskShift
+            | (kCGEventFlagMaskShift
                if Key.shift in modifiers else 0))
 
         if vk is None and self.char is not None:
-            Quartz.CGEventKeyboardSetUnicodeString(
+            CGEventKeyboardSetUnicodeString(
                 result, len(self.char), self.char)
 
         return result
@@ -201,8 +208,8 @@ class Controller(_base.Controller):
 
     def _handle(self, key, is_press):
         with self.modifiers as modifiers:
-            Quartz.CGEventPost(
-                Quartz.kCGHIDEventTap,
+            CGEventPost(
+                kCGHIDEventTap,
                 (key if key not in (k for k in Key) else key.value)._event(
                     modifiers, self._mapping, is_press))
 
@@ -210,10 +217,10 @@ class Controller(_base.Controller):
 class Listener(ListenerMixin, _base.Listener):
     #: The events that we listen to
     _EVENTS = (
-        Quartz.CGEventMaskBit(Quartz.kCGEventKeyDown) |
-        Quartz.CGEventMaskBit(Quartz.kCGEventKeyUp) |
-        Quartz.CGEventMaskBit(Quartz.kCGEventFlagsChanged) |
-        Quartz.CGEventMaskBit(Quartz.NSSystemDefined)
+        CGEventMaskBit(kCGEventKeyDown) |
+        CGEventMaskBit(kCGEventKeyUp) |
+        CGEventMaskBit(kCGEventFlagsChanged) |
+        CGEventMaskBit(NSSystemDefined)
     )
 
     # pylint: disable=W0212
@@ -225,18 +232,18 @@ class Listener(ListenerMixin, _base.Listener):
 
     #: The event flags set for the various modifier keys
     _MODIFIER_FLAGS = {
-        Key.alt: Quartz.kCGEventFlagMaskAlternate,
-        Key.alt_l: Quartz.kCGEventFlagMaskAlternate,
-        Key.alt_r: Quartz.kCGEventFlagMaskAlternate,
-        Key.cmd: Quartz.kCGEventFlagMaskCommand,
-        Key.cmd_l: Quartz.kCGEventFlagMaskCommand,
-        Key.cmd_r: Quartz.kCGEventFlagMaskCommand,
-        Key.ctrl: Quartz.kCGEventFlagMaskControl,
-        Key.ctrl_l: Quartz.kCGEventFlagMaskControl,
-        Key.ctrl_r: Quartz.kCGEventFlagMaskControl,
-        Key.shift: Quartz.kCGEventFlagMaskShift,
-        Key.shift_l: Quartz.kCGEventFlagMaskShift,
-        Key.shift_r: Quartz.kCGEventFlagMaskShift}
+        Key.alt: kCGEventFlagMaskAlternate,
+        Key.alt_l: kCGEventFlagMaskAlternate,
+        Key.alt_r: kCGEventFlagMaskAlternate,
+        Key.cmd: kCGEventFlagMaskCommand,
+        Key.cmd_l: kCGEventFlagMaskCommand,
+        Key.cmd_r: kCGEventFlagMaskCommand,
+        Key.ctrl: kCGEventFlagMaskControl,
+        Key.ctrl_l: kCGEventFlagMaskControl,
+        Key.ctrl_r: kCGEventFlagMaskControl,
+        Key.shift: kCGEventFlagMaskShift,
+        Key.shift_l: kCGEventFlagMaskShift,
+        Key.shift_r: kCGEventFlagMaskShift}
 
     def __init__(self, *args, **kwargs):
         super(Listener, self).__init__(*args, **kwargs)
@@ -263,11 +270,11 @@ class Listener(ListenerMixin, _base.Listener):
             key = None
 
         try:
-            if event_type == Quartz.kCGEventKeyDown:
+            if event_type == kCGEventKeyDown:
                 # This is a normal key press
                 self.on_press(key)
 
-            elif event_type == Quartz.kCGEventKeyUp:
+            elif event_type == kCGEventKeyUp:
                 # This is a normal key release
                 self.on_release(key)
 
@@ -277,8 +284,8 @@ class Listener(ListenerMixin, _base.Listener):
                 self.on_press(key)
                 self.on_release(key)
 
-            elif event_type == Quartz.NSSystemDefined:
-                sys_event = Quartz.NSEvent.eventWithCGEvent_(event)
+            elif event_type == NSSystemDefined:
+                sys_event = NSEvent.eventWithCGEvent_(event)
                 if sys_event.subtype() == kSystemDefinedEventMediaKeysSubtype:
                     # The key in the special key dict; True since it is a media
                     # key
@@ -295,7 +302,7 @@ class Listener(ListenerMixin, _base.Listener):
                 # This is a modifier event---excluding caps lock---for which we
                 # must check the current modifier state to determine whether
                 # the key was pressed or released
-                flags = Quartz.CGEventGetFlags(event)
+                flags = CGEventGetFlags(event)
                 is_press = flags & self._MODIFIER_FLAGS.get(key, 0)
                 if is_press:
                     self.on_press(key)
@@ -305,7 +312,7 @@ class Listener(ListenerMixin, _base.Listener):
         finally:
             # Store the current flag mask to be able to detect modifier state
             # changes
-            self._flags = Quartz.CGEventGetFlags(event)
+            self._flags = CGEventGetFlags(event)
 
     def _event_to_key(self, event):
         """Converts a *Quartz* event to a :class:`KeyCode`.
@@ -316,10 +323,10 @@ class Listener(ListenerMixin, _base.Listener):
 
         :raises IndexError: if the key code is invalid
         """
-        vk = Quartz.CGEventGetIntegerValueField(
-            event, Quartz.kCGKeyboardEventKeycode)
-        event_type = Quartz.CGEventGetType(event)
-        is_media = True if event_type == Quartz.NSSystemDefined else None
+        vk = CGEventGetIntegerValueField(
+            event, kCGKeyboardEventKeycode)
+        event_type = CGEventGetType(event)
+        is_media = True if event_type == NSSystemDefined else None
 
         # First try special keys...
         key = (vk, is_media)
@@ -327,7 +334,7 @@ class Listener(ListenerMixin, _base.Listener):
             return self._SPECIAL_KEYS[key]
 
         # ...then try characters...
-        length, chars = Quartz.CGEventKeyboardGetUnicodeString(
+        length, chars = CGEventKeyboardGetUnicodeString(
             event, 100, None, None)
         if length > 0:
             return KeyCode.from_char(chars, vk=vk)


### PR DESCRIPTION
This avoids a race condition in the lazy importer in PyObjC 7 or
earlier, which might result in AttributeErrors when getting the
same unresolved attribute on two threads at the same time.

This should fix #55