### PR TITLE
Added media stop key for Linux and Windows

### DIFF
--- a/lib/pynput/keyboard/_base.py
+++ b/lib/pynput/keyboard/_base.py
@@ -281,6 +281,9 @@ class Key(enum.Enum):
 
     #: The play/pause toggle.
     media_play_pause = 0
+    
+    #: The stop button.
+    media_stop = 0
 
     #: The volume mute button.
     media_volume_mute = 0

--- a/lib/pynput/keyboard/_uinput.py
+++ b/lib/pynput/keyboard/_uinput.py
@@ -122,6 +122,7 @@ class Key(enum.Enum):
     up = KeyCode._from_name('Up', 'KEY_UP')
 
     media_play_pause = KeyCode._from_name('Play', 'KEY_PLAYPAUSE')
+    media_stop = KeyCode._from_name('Stop', 'KEY_STOP')
     media_volume_mute = KeyCode._from_name('Mute', 'KEY_MUTE')
     media_volume_down = KeyCode._from_name('LowerVolume', 'KEY_VOLUMEDOWN')
     media_volume_up = KeyCode._from_name('RaiseVolume', 'KEY_VOLUMEUP')

--- a/lib/pynput/keyboard/_win32.py
+++ b/lib/pynput/keyboard/_win32.py
@@ -160,6 +160,7 @@ class Key(enum.Enum):
     up = KeyCode._from_ext(VK.UP)
 
     media_play_pause = KeyCode._from_ext(VK.MEDIA_PLAY_PAUSE)
+    media_stop = KeyCode._from_ext(VK.MEDIA_STOP)
     media_volume_mute = KeyCode._from_ext(VK.VOLUME_MUTE)
     media_volume_down = KeyCode._from_ext(VK.VOLUME_DOWN)
     media_volume_up = KeyCode._from_ext(VK.VOLUME_UP)

--- a/lib/pynput/keyboard/_xorg.py
+++ b/lib/pynput/keyboard/_xorg.py
@@ -166,6 +166,7 @@ class Key(enum.Enum):
     up = KeyCode._from_symbol('Up')
 
     media_play_pause = KeyCode._from_media('Play')
+    media_stop = KeyCode._from_media('Stop')
     media_volume_mute = KeyCode._from_media('Mute')
     media_volume_down = KeyCode._from_media('LowerVolume')
     media_volume_up = KeyCode._from_media('RaiseVolume')


### PR DESCRIPTION
I have added code for the multimedia stop key since it is missing and I needed it for a program. I have added it and tested it for Linux and Windows, I don't have a Mac OS machine to test it on.