### PR TITLE
Move pynput man page to section 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,4 +77,4 @@ man_pages = [
         package.__package__,
         u'%s Documentation' % package.__package__,
         [package._info.__author__],
-        1)]
+        3)]


### PR DESCRIPTION
Man page section 1 is used for commands, but pynput is a Python library and does not ship a binary. Therefore move it to section 3 (which is used for library functions).