### PR TITLE
Submodules relative imports

### DIFF
--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -25,7 +25,7 @@ See the documentation for more information.
 
 import itertools
 
-from pynput._util import backend, Events
+from .._util import backend, Events
 
 
 backend = backend(__name__)

--- a/lib/pynput/keyboard/_base.py
+++ b/lib/pynput/keyboard/_base.py
@@ -31,8 +31,8 @@ import unicodedata
 
 import six
 
-from pynput._util import AbstractListener, prefix
-from pynput import _logger
+from .._util import AbstractListener, prefix
+from .. import _logger
 
 
 class KeyCode(object):
@@ -728,7 +728,7 @@ class Listener(AbstractListener):
         :return: a key
         :rtype: Key or KeyCode
         """
-        from pynput.keyboard import Key, KeyCode, _NORMAL_MODIFIERS
+        from . import Key, KeyCode, _NORMAL_MODIFIERS
         if isinstance(key, KeyCode) and key.char is not None:
             return KeyCode.from_char(key.char.lower())
         elif isinstance(key, Key) and key.value in _NORMAL_MODIFIERS:

--- a/lib/pynput/keyboard/_darwin.py
+++ b/lib/pynput/keyboard/_darwin.py
@@ -28,7 +28,7 @@ import enum
 
 import Quartz
 
-from pynput._util.darwin import (
+from .._util.darwin import (
     get_unicode_to_keycode_map,
     keycode_context,
     ListenerMixin)

--- a/lib/pynput/keyboard/_uinput.py
+++ b/lib/pynput/keyboard/_uinput.py
@@ -35,8 +35,8 @@ import evdev
 
 from evdev.events import KeyEvent
 
-from pynput._util import xorg_keysyms
-from pynput._util.uinput import ListenerMixin
+from .._util import xorg_keysyms
+from .._util.uinput import ListenerMixin
 from . import _base
 
 

--- a/lib/pynput/keyboard/_win32.py
+++ b/lib/pynput/keyboard/_win32.py
@@ -31,10 +31,10 @@ import six
 
 from ctypes import wintypes
 
-import pynput._util.win32_vks as VK
+from .._util import win32_vks as VK
 
-from pynput._util import AbstractListener
-from pynput._util.win32 import (
+from .._util import AbstractListener
+from .._util.win32 import (
     INPUT,
     INPUT_union,
     KEYBDINPUT,

--- a/lib/pynput/keyboard/_xorg.py
+++ b/lib/pynput/keyboard/_xorg.py
@@ -26,7 +26,7 @@ The keyboard implementation for *Xorg*.
 
 # pylint: disable=W0611
 try:
-    import pynput._util.xorg
+    from .._util import xorg
 except Exception as e:
     raise ImportError('failed to acquire X connection: {}'.format(str(e)), e)
 # pylint: enable=W0611
@@ -42,8 +42,8 @@ import Xlib.XK
 import Xlib.protocol
 import Xlib.keysymdef.xkb
 
-from pynput._util import NotifierMixin
-from pynput._util.xorg import (
+from .._util import NotifierMixin
+from .._util.xorg import (
     alt_mask,
     alt_gr_mask,
     char_to_keysym,
@@ -54,7 +54,7 @@ from pynput._util.xorg import (
     numlock_mask,
     shift_to_index,
     symbol_to_keysym)
-from pynput._util.xorg_keysyms import (
+from .._util.xorg_keysyms import (
     CHARS,
     DEAD_KEYS,
     KEYPAD_KEYS,

--- a/lib/pynput/mouse/__init__.py
+++ b/lib/pynput/mouse/__init__.py
@@ -23,7 +23,7 @@ See the documentation for more information.
 # pylint: disable=C0103
 # Button, Controller and Listener are not constants
 
-from pynput._util import backend, Events
+from .._util import backend, Events
 
 
 backend = backend(__name__)

--- a/lib/pynput/mouse/_base.py
+++ b/lib/pynput/mouse/_base.py
@@ -26,8 +26,8 @@ is located in a platform dependent module.
 
 import enum
 
-from pynput._util import AbstractListener, prefix
-from pynput import _logger
+from .._util import AbstractListener, prefix
+from .. import _logger
 
 
 class Button(enum.Enum):

--- a/lib/pynput/mouse/_darwin.py
+++ b/lib/pynput/mouse/_darwin.py
@@ -29,7 +29,7 @@ import Quartz
 
 from AppKit import NSEvent
 
-from pynput._util.darwin import (
+from .._util.darwin import (
     ListenerMixin)
 from . import _base
 

--- a/lib/pynput/mouse/_win32.py
+++ b/lib/pynput/mouse/_win32.py
@@ -31,8 +31,8 @@ from ctypes import (
     windll,
     wintypes)
 
-from pynput._util import NotifierMixin
-from pynput._util.win32 import (
+from .._util import NotifierMixin
+from .._util.win32 import (
     INPUT,
     INPUT_union,
     ListenerMixin,

--- a/lib/pynput/mouse/_xorg.py
+++ b/lib/pynput/mouse/_xorg.py
@@ -30,7 +30,7 @@ The keyboard implementation for *Xorg*.
 
 # pylint: disable=W0611
 try:
-    import pynput._util.xorg
+    from .._util import xorg
 except Exception as e:
     raise ImportError('failed to acquire X connection: {}'.format(str(e)), e)
 # pylint: enable=W0611
@@ -42,7 +42,7 @@ import Xlib.ext.xtest
 import Xlib.X
 import Xlib.protocol
 
-from pynput._util.xorg import (
+from .._util.xorg import (
     display_manager,
     ListenerMixin)
 from . import _base


### PR DESCRIPTION
There are systems where pynput is not packaged, so I had to use it as an application submodule. This is what I needed to do.