### PR TITLE
Fix Hotkeys that are not modifiers or characters not working

### DIFF
--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -144,7 +144,9 @@ class HotKey(object):
             elif len(s) > 2 and (s[0], s[-1]) == ('<', '>'):
                 p = s[1:-1]
                 try:
-                    return Key[p.lower()]
+                    if Key[p.lower()] in _NORMAL_MODIFIERS.values():
+                        return Key[p.lower()]
+                    return KeyCode.from_vk(Key[p.lower()].value.vk)
                 except KeyError:
                     try:
                         return KeyCode.from_vk(int(p))


### PR DESCRIPTION
When creating hotkeys, some keys were not working, particularly those that are not modifiers or characters (e.g. Esc, Page Down, Arrows, End, etc...) The Key enums were getting added to the list of hotkeys by the parsing function instead of the KeyCode. I added logic to check if the key is not a modifier, and if its not, create and add the KeyCode to the hotkey instead. I made the change to Hotkey.parse()