### PR TITLE
Improve performance by reducing ctypes calls

### DIFF
--- a/lib/pynput/_util/win32.py
+++ b/lib/pynput/_util/win32.py
@@ -462,6 +462,10 @@ class KeyTranslator(object):
 
     def __init__(self):
         self.update_layout()
+        self._modifier_state = [False, False, False]
+        self.keyIndex = {0x10: 0, 0xA0: 0, 0xA1: 0,
+                         0x11: 1, 0xA2: 1, 0xA3: 1,
+                         0x12: 2, 0xA4: 2, 0xA5: 2}
 
     def __call__(self, vk, is_press):
         """Converts a virtual key code to a string.
@@ -476,7 +480,10 @@ class KeyTranslator(object):
         :raises OSError: if a call to any *win32* function fails
         """
         # Get a string representation of the key
-        layout_data = self._layout_data[self._modifier_state()]
+        try: self._modifier_state[self.keyIndex[vk]] = is_press
+        except KeyError: pass
+        
+        layout_data = self._layout_data[tuple(self._modifier_state)]
         scan = self._to_scan(vk, self._layout)
         character, is_dead = layout_data[scan]
 


### PR DESCRIPTION
From my testing (albeit with a quite heavily modified version of this script), this provides a roughly 30x performance boost with measurements taken from the first line of ``_modifier_state`` to the line after the ``layout_data`` assignment in ``__call__`` for the unmodified version and from the first line of ``__call__`` to the line after the ``layout_data`` assignment in ``__call__``.

The test was conducting by pressing 4 regular keys (asdf), 4 shift keys ("!#¤), 2 more shift keys (() open and close parentheses) and then 2 ctrl+alt keys ([] open and close brackets). After this, I made a sum of all the measured times between the previously mentioned lines and compared those sums with each other.

From my research, there shouldn't be any problem with some keyboards having different shift/ctrl/alt keys since the vkCodes for these should be the same across all keyboard according this documentation: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes

IMPORTANT NOTE: This would also require a change to ``Listener._event_to_key`` in ``keyboard/_win32.py`` since it as of now does not pass "special keys" to ``KeyTranslator`` at all, however, I think that the ``KeyTranslator`` class should be the one to deal with those as well (especially since it already has access to the ``win32_vks.py`` module)

As a final note I would just like to say that I've enjoyed sifting through this project to extract the parts needed for my own and I want to thank everyone that has contributed to it