### PR TITLE
Win32 suppress after enqueue

### DIFF
--- a/lib/pynput/_util/win32.py
+++ b/lib/pynput/_util/win32.py
@@ -389,7 +389,7 @@ class ListenerMixin(object):
         except NotImplementedError:
             self._handle(code, msg, lpdata)
 
-        if self.suppress:
+        if self.suppress or self._get_suppress_after(msg, lpdata):
             self.suppress_event()
 
     def _convert(self, code, msg, lpdata):
@@ -399,6 +399,9 @@ class ListenerMixin(object):
         ``WPARAM`` / ``LPARAM`` pair.
         """
         raise NotImplementedError()
+
+    def _get_suppress_after(self, msg, lpdata):
+        raise NotImplementedError
 
     def _process(self, wparam, lparam):
         """The device specific callback handler.

--- a/lib/pynput/keyboard/_win32.py
+++ b/lib/pynput/keyboard/_win32.py
@@ -248,12 +248,13 @@ class Listener(ListenerMixin, _base.Listener):
         self._event_filter = self._options.get(
             'event_filter',
             lambda msg, data: True)
+        self._get_suppress_after_ = self._options.get("get_suppress_after")
 
     def _convert(self, code, msg, lpdata):
         if code != SystemHook.HC_ACTION:
             return
 
-        data = ctypes.cast(lpdata, self._LPKBDLLHOOKSTRUCT).contents
+        data = self._get_data(lpdata)
         is_packet = data.vkCode == self._VK_PACKET
 
         # Suppress further propagation of the event if it is filtered
@@ -263,6 +264,14 @@ class Listener(ListenerMixin, _base.Listener):
             return (msg | self._UTF16_FLAG, data.scanCode)
         else:
             return (msg, data.vkCode)
+
+    def _get_suppress_after(self, msg, lpdata):
+        if self._get_suppress_after_ is None:
+            return False
+        return self._get_suppress_after_(msg, self._get_data(lpdata))
+
+    def _get_data(self, lpdata):
+        return ctypes.cast(lpdata, self._LPKBDLLHOOKSTRUCT).contents
 
     @AbstractListener._emitter
     def _process(self, wparam, lparam):


### PR DESCRIPTION
This adds an option specific to win32 which introduces a new filter.

The existing filter either suppresses the event early in case of `raise ...`, or ignores the event and passes it on in case of `return False` (the comment `# Suppress further propagation of the event if it is filtered` is plain wrong)

The new filter suppresses events after they have been enqueued.

This allows suppression of injected events as demonstrated in https://gitlab.com/notEvil/keyboard/-/blob/a868e952787d0a779b129f9382c00d907fc16a2a/keyboard/windows/evdev/__init__.py#L32 and might solve issues like https://github.com/moses-palmer/pynput/issues/455.

Feel free to adjust names and code style