### PR TITLE
Change keycode_context on Darwin keyboard Listener

### DIFF
--- a/lib/pynput/keyboard/_darwin.py
+++ b/lib/pynput/keyboard/_darwin.py
@@ -248,12 +248,13 @@ class Listener(ListenerMixin, _base.Listener):
             None)
 
     def _run(self):
-        with keycode_context() as context:
-            self._context = context
-            try:
-                super(Listener, self)._run()
-            finally:
-                self._context = None
+        #with keycode_context() as context:
+        context = keycode_context()
+        self._context = context
+        try:
+            super(Listener, self)._run()
+        finally:
+            self._context = None
 
     def _handle(self, _proxy, event_type, event, _refcon):
         # Convert the event to a KeyCode; this may fail, and in that case we


### PR DESCRIPTION
Creating a pynput keyboard Listener after starting a GUI (pyside6, pyqt6, tkinter) on macOS (Monterey, M1) crashes Python.

Funny enough, creating a Controller on the same spot doesn't generate a crash, so this is a simple "fix" to imitate the way Controller starts on macOS in Listener.

Should fix #511