### PR TITLE
make Listener.canonical a staticmethod, this make the call from callabacks easier.

### DIFF
--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -185,7 +185,8 @@ class HotKey(object):
         if key in self._keys and key not in self._state:
             self._state.add(key)
             if self._state == self._keys:
-                self._on_activate()
+                if self._on_activate() is False:
+                    raise Listener.StopException()
 
     def release(self, key):
         """Updates the hotkey state for a released key.

--- a/lib/pynput/keyboard/_base.py
+++ b/lib/pynput/keyboard/_base.py
@@ -712,7 +712,8 @@ class Listener(AbstractListener):
             on_press=on_press, on_release=on_release, suppress=suppress)
 # pylint: enable=W0223
 
-    def canonical(self, key):
+    @staticmethod
+    def canonical(key):
         """Performs normalisation of a key.
 
         This method attempts to convert key events to their canonical form, so

--- a/tools/keyboard-mixin-test.py
+++ b/tools/keyboard-mixin-test.py
@@ -1,0 +1,48 @@
+
+# insert in front of sys.path because of system package already installed
+import os
+import sys
+sys.path.insert(0,
+    os.path.join(os.path.dirname(__file__), '..', 'lib'))
+
+from pynput import keyboard
+
+"""
+I was looking for a way to use both HotKeys and regular callabacks
+(i.e. on_press and on_release) and still being able to pass the
+suppress argument to the Listener.
+
+The main issue here is the call for keyboard.Listener.canonical.
+"""
+
+def on_ctrl_c():
+    print("=> HotKey('<ctrl>+c')")
+    raise keyboard.Listener.StopException()
+
+hotkeys = [
+    keyboard.HotKey(
+        keyboard.HotKey.parse('<ctrl>+c'),
+        on_ctrl_c)
+]
+
+def on_press(key):
+    print("=> {}".format(key))
+    can_key = keyboard.Listener.canonical(key)
+    for hk in hotkeys:
+        hk.press(can_key)
+
+def on_release(key):
+    print("=< {}".format(key))
+    if key == keyboard.Key.esc:
+        return False
+    can_key = keyboard.Listener.canonical(key)
+    for hk in hotkeys:
+        hk.release(can_key)
+
+
+with keyboard.Listener(
+        on_press=on_press,
+        on_release=on_release,
+        suppress=True) as listener:
+    print("Press ESC or Ctrl-C to exit")
+    listener.join()

--- a/tools/keyboard-mixin-test.py
+++ b/tools/keyboard-mixin-test.py
@@ -9,19 +9,21 @@ import functools
 
 from pynput import keyboard
 
+__author__ = "Paolo Pastori"
+
 """
 I was looking for a way to use both HotKeys and regular callabacks
 (i.e. on_press and on_release) and still being able to pass the
 suppress argument to the Listener.
 
-The main issue here is the call for keyboard.Listener.canonical.
+The main issue was the call for keyboard.Listener.canonical.
 """
 
 # these might be provided by the package
 def notify_hotkeys(hotkeys, is_press):
-    """Decorator to add HotKey capabilities to event callbacks.
+    """Decorator factory to add HotKey capabilities to event callbacks.
     """
-    def decorator_factory(callback):
+    def decorator(callback):
         @functools.wraps(callback)
         def wrapper(key):
             if callback(key) is False:
@@ -31,7 +33,7 @@ def notify_hotkeys(hotkeys, is_press):
             for hk in hotkeys:
                 getattr(hk, hot_callback)(can_key)
         return wrapper
-    return decorator_factory
+    return decorator
 
 def activate_hotkeys(hotkeys):
     return notify_hotkeys(hotkeys, True)
@@ -42,8 +44,7 @@ def deactivate_hotkeys(hotkeys):
 
 def on_ctrl_c():
     print("=> HotKey('<ctrl>+c')")
-    # here return False should work as for other callbacks
-    raise keyboard.Listener.StopException()
+    return False
 
 hotkeys = [
     keyboard.HotKey(


### PR DESCRIPTION
I have added the script tools/keyboard-mixin-test.py as a proof of the concept.
Tested with Linux (xorg).
But I was unable to run the tests, sorry.