### PR TITLE
Add key pressed time

### DIFF
--- a/lib/pynput/_util/win32.py
+++ b/lib/pynput/_util/win32.py
@@ -358,7 +358,7 @@ class ListenerMixin(object):
                         if not self.running:
                             break
                         if msg.message == self._WM_PROCESS:
-                            self._process(msg.wParam, msg.lParam)
+                            self._process(msg.wParam, msg.lParam, msg.time)
                         elif msg.message in self._WM_NOTIFICATIONS:
                             self._on_notification(
                                 msg.message, msg.wParam, msg.lParam)
@@ -400,7 +400,7 @@ class ListenerMixin(object):
         """
         raise NotImplementedError()
 
-    def _process(self, wparam, lparam):
+    def _process(self, wparam, lparam, time):
         """The device specific callback handler.
 
         This method performs the actual dispatching of events.

--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -79,16 +79,18 @@ class Events(Events):
     class Press(Events.Event):
         """A key press event.
         """
-        def __init__(self, key):
+        def __init__(self, key, time):
             #: The key.
             self.key = key
+            self.time = time
 
     class Release(Events.Event):
         """A key release event.
         """
-        def __init__(self, key):
+        def __init__(self, key, time):
             #: The key.
             self.key = key
+            self.time = time
 
     def __init__(self):
         super(Events, self).__init__(

--- a/lib/pynput/keyboard/_win32.py
+++ b/lib/pynput/keyboard/_win32.py
@@ -294,7 +294,7 @@ class Listener(ListenerMixin, _base.Listener):
             return (msg, data.vkCode)
 
     @AbstractListener._emitter
-    def _process(self, wparam, lparam):
+    def _process(self, wparam, lparam, time):
         msg = wparam
         vk = lparam
 
@@ -311,12 +311,13 @@ class Listener(ListenerMixin, _base.Listener):
                 key = self._event_to_key(msg, vk)
             except OSError:
                 key = None
+                time = None
 
         if msg in self._PRESS_MESSAGES:
-            self.on_press(key)
+            self.on_press(key, time)
 
         elif msg in self._RELEASE_MESSAGES:
-            self.on_release(key)
+            self.on_release(key, time)
 
     # pylint: disable=R0201
     @contextlib.contextmanager

--- a/tools/keyboard-test.py
+++ b/tools/keyboard-test.py
@@ -6,14 +6,14 @@ sys.path.append(
 from pynput import keyboard
 
 
-def on_press(key):
-    print('=> %s' % key)
+def on_press(key, time):
+    print('%r => %s' % (time, key))
     if key == keyboard.Key.esc:
         return False
 
 
-def on_release(key):
-    print('=< %s' % key)
+def on_release(key, time):
+    print('%r =< %s' % (time, key))
 
 
 with keyboard.Listener(


### PR DESCRIPTION
This would be useful to have the time when the key was pressed. 

Don't know how to apply this to the other systems and don't have access to test so i leaved it unchanged.

In general it would be much nicer to receive a key event instead of just the key character. 
The event could contain the key character and time also the vk_code or scan_code would be useful to have.