### PR TITLE
Correctly disables the XRecord context. (probably)

### DIFF
--- a/lib/pynput/_util/xorg.py
+++ b/lib/pynput/_util/xorg.py
@@ -425,7 +425,8 @@ class ListenerMixin(object):
             self.wait()
 
         # Do this asynchronously to avoid deadlocks
-        self._display_record.record_disable_context(self._context)
+        self._display_stop.record_disable_context(self._context)
+        self._display_stop.flush()
 
     def _suppress_start(self, display):
         """Starts suppressing events.


### PR DESCRIPTION
When using pynput on a Xorg server, if I start a MouseListener and/or KeyboardListener, stop it after a while, and then join, it does not join immediately. The join will not be completed until a mouse or key event occurs afterward. A test program can be retrieved from the following gist:

https://gist.github.com/fukuchi/b06c30f04cd69b396f127d2b781c1ff3

This is because the context enabled in _run() in _util/xorg.py is not correctly disabled in _stop_platform().

This pull request fixes this problem. However, I am not familiar with Xlib programming and XRecord extensions, so I am not sure why this works correctly.

I have tested this patch on Ubuntu 22.04 (Python 3.10.12) and Ubuntu 23.10 (Python 3.11.6).
