### PR TITLE
Update mouse-usage.rst because code produces error

### DIFF
--- a/docs/mouse-usage.rst
+++ b/docs/mouse-usage.rst
@@ -156,12 +156,14 @@ To iterate over mouse events, use the following code::
 
     from pynput import mouse
 
-    # The event listener will be running in this block
     with mouse.Events() as events:
         for event in events:
-            if event.button == mouse.Button.right:
-                break
-            else:
+            try:
+                if event.button == mouse.Button.right:
+                    print('Right button clicked!')
+                    break
+            except: pass
+            finally:
                 print('Received event {}'.format(event))
 
 Please note that the iterator method does not support non-blocking operation,


### PR DESCRIPTION
Main problem was that event may not have attribute .button as the error indicates.

mouse.Events() can have 3 main types: pynput.mouse.Events.Click, pynput.mouse.Events.Move and pynput.mouse.Events.Scroll (as far as I know)

And among those three, last two of those do not have attribute .button surely.

So if we want to handle this problem, I guess we need to use exception handling.


https://stackoverflow.com/questions/73543563/attributeerror-move-object-has-no-attribute-button-mouse-listener-with-pyn