### PR TITLE
map eject key on Magic Keyboard

### DIFF
--- a/lib/pynput/keyboard/_darwin.py
+++ b/lib/pynput/keyboard/_darwin.py
@@ -63,6 +63,7 @@ NX_KEYTYPE_SOUND_DOWN = 1
 NX_KEYTYPE_SOUND_UP = 0
 NX_KEYTYPE_NEXT = 17
 NX_KEYTYPE_PREVIOUS = 18
+NX_KEYTYPE_EJECT = 14
 
 # pylint: disable=C0103; We want to use the names from the C API
 # This is undocumented, but still widely known
@@ -209,6 +210,7 @@ class Key(enum.Enum):
     media_volume_up = KeyCode._from_media(NX_KEYTYPE_SOUND_UP)
     media_previous = KeyCode._from_media(NX_KEYTYPE_PREVIOUS)
     media_next = KeyCode._from_media(NX_KEYTYPE_NEXT)
+    media_eject = KeyCode._from_media(NX_KEYTYPE_EJECT)
 # pylint: enable=W0212
 
 


### PR DESCRIPTION
I added another Key enum to map the eject key on the magic keyboard. It was listed in ev_keymap.h so I added it here to make the eject key useful. 