### PR TITLE
remove xorg _handle merge artefact

### DIFF
--- a/lib/pynput/_util/xorg.py
+++ b/lib/pynput/_util/xorg.py
@@ -469,7 +469,6 @@ class ListenerMixin(object):
                 data, self._display_record.display, None, None)
 
             injected = event.send_event
-            self._handle(self._display_stop, event, injected)
             self._handle_message(self._display_stop, event, injected)
 
     def _initialize(self, display):


### PR DESCRIPTION
I run into the [Issue 633](https://github.com/moses-palmer/pynput/issues/633).

I removed the Line, because it is obviously  a merge artifact. 