### PR TITLE
Add missing injected parameter (fixes random crashes on macOS)

### DIFF
--- a/lib/pynput/keyboard/_darwin.py
+++ b/lib/pynput/keyboard/_darwin.py
@@ -310,9 +310,9 @@ class Listener(ListenerMixin, _base.Listener):
                         flags = sys_event.data1() & 0x0000ffff
                         is_press = ((flags & 0xff00) >> 8) == 0x0a
                         if is_press:
-                            self.on_press(self._SPECIAL_KEYS[key])
+                            self.on_press(self._SPECIAL_KEYS[key], injected)
                         else:
-                            self.on_release(self._SPECIAL_KEYS[key])
+                            self.on_release(self._SPECIAL_KEYS[key], injected)
 
             else:
                 # This is a modifier event---excluding caps lock---for which we


### PR DESCRIPTION
I had this code in my program:
```py
from pynput import keyboard

key_combos = {}
key_combos['<ctrl_l>+a'] = pause_handler
key_combos['<ctrl_l>+s'] = engine_change_handler

key_combo_listener = keyboard.GlobalHotKeys(key_combos)
key_combo_listener.start()
```

Which randomly yielded these exceptions in 1.8.1:
```
Unhandled exception in listener callback
Traceback (most recent call last):
  File "/Users/aurora/.pyenv/versions/owocr/lib/python3.13/site-packages/pynput/_util/__init__.py", line 230, in inner
    return f(self, *args, **kwargs)
  File "/Users/aurora/.pyenv/versions/owocr/lib/python3.13/site-packages/pynput/_util/darwin.py", line 290, in _handler
    self._handle_message(proxy, event_type, event, refcon, is_injected)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aurora/.pyenv/versions/owocr/lib/python3.13/site-packages/pynput/keyboard/_darwin.py", line 313, in _handle_message
    self.on_press(self._SPECIAL_KEYS[key])
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aurora/.pyenv/versions/owocr/lib/python3.13/site-packages/pynput/_util/__init__.py", line 146, in inner
    if f(*args) is False:
       ~^^^^^^^
TypeError: GlobalHotKeys._on_press() missing 1 required positional argument: 'injected'
```