### PR TITLE
Clarify point when referring to requirement for X

### DIFF
--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -23,7 +23,7 @@ When running under *uinput*, the following must be true:
 
 Also please note that the ``injected`` flag is not supported for *uinput*.
 
-The latter requirement for *X* means that running *pynput* over *SSH* generally
+The former requirement for *X* means that running *pynput* over *SSH* generally
 will not work. To work around that, make sure to set ``$DISPLAY``:
 
 .. code-block:: bash


### PR DESCRIPTION
In this context "latter" is referring to the point about uinput.  I think you may have meant "former" to refer to the point about X.