### PR TITLE
listen to keyboard from an async loop

### DIFF
--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -23,7 +23,10 @@ See the documentation for more information.
 # pylint: disable=C0103
 # KeyCode, Key, Controller and Listener are not constants
 
+import asyncio
 import itertools
+import sys
+from functools import cached_property, wraps
 
 from pynput._util import backend, Events
 
@@ -247,3 +250,59 @@ class GlobalHotKeys(Listener):
         if not injected:
             for hotkey in self._hotkeys:
                 hotkey.release(self.canonical(key))
+
+
+class AsyncListener:
+    """Run keyboard listener from an async loop.
+
+    After catching the keys pressed in the thread, it transmits the tasks to be
+    processed in the event loop.
+    """
+    def __init__(self, on_press=None, on_release=None, suppress=False, **kwargs):
+        self.running = False
+
+        self._listener = Listener(
+            on_press=self._transmit_to_event_loop(on_press),
+            on_release=self._transmit_to_event_loop(on_release),
+            suppress=suppress,
+            **kwargs
+        )
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
+    @cached_property
+    def _loop(self):
+        # Prefer the encoraged usage of running_loop, but be compatible with older python.
+        # This cannot be instantiated until the loop is surely running.
+        _version = sys.version_info
+        return asyncio.get_running_loop if _version >= (3, 7) else asyncio.get_event_loop
+
+    def _transmit_to_event_loop(self, func):
+        @wraps(func)
+        def wrapper(key):
+            return self._loop.call_soon_threadsafe(func, key)
+
+        @wraps(func)
+        def async_wrapper(key):
+            return asyncio.run_coroutine_threadsafe(func(key), self._loop)
+
+        if func is None:
+            return None
+        elif asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        else:
+            return wrapper
+
+    def start(self):
+        self._listener.start()
+        self.running = True
+
+    def stop(self):
+        self._listener.stop()
+        self._listener.join()
+        self.running = False

--- a/lib/pynput/keyboard/__init__.py
+++ b/lib/pynput/keyboard/__init__.py
@@ -252,6 +252,13 @@ class GlobalHotKeys(Listener):
                 hotkey.release(self.canonical(key))
 
 
+# Prefer the encoraged usage of running_loop, but be compatible with older python.
+# In the latest python this cannot be instantiated until the loop is surely running.
+if sys.version_info >= (3, 7):
+    _get_loop = asyncio.get_running_loop
+else:
+    _get_loop = asyncio.get_event_loop
+
 class AsyncListener:
     """Run keyboard listener from an async loop.
 
@@ -259,6 +266,7 @@ class AsyncListener:
     processed in the event loop.
     """
     def __init__(self, on_press=None, on_release=None, suppress=False, **kwargs):
+        self._loop = None
         self.running = False
 
         self._listener = Listener(
@@ -274,13 +282,6 @@ class AsyncListener:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
-
-    @cached_property
-    def _loop(self):
-        # Prefer the encoraged usage of running_loop, but be compatible with older python.
-        # This cannot be instantiated until the loop is surely running.
-        _version = sys.version_info
-        return asyncio.get_running_loop if _version >= (3, 7) else asyncio.get_event_loop
 
     def _transmit_to_event_loop(self, func):
         @wraps(func)
@@ -299,6 +300,7 @@ class AsyncListener:
             return wrapper
 
     def start(self):
+        self._loop = _get_loop()
         self._listener.start()
         self.running = True
 


### PR DESCRIPTION
Currently the `on_press` is processed in the listener thread.
It makes it hard to use with async apps.
Some packages (like `ib_insync`) that uses async loops are unable to run well under these restriction.

I Added an `AsyncListener` class, to be able to run the listener and transmit the calls from the listener thread to the event loop.