### PR TITLE
Add regression test for duplicate on_scroll on Windows

### DIFF
--- a/tests/mouse_controller_tests.py
+++ b/tests/mouse_controller_tests.py
@@ -186,3 +186,25 @@ class MouseControllerTest(EventTest):
                 'Failed to send scroll down event',
                 on_scroll=lambda x, y, dx, dy: dy < 0):
             self.controller.scroll(0, -1)
+
+    def test_scroll_no_duplicate(self):
+        """Tests that a single scroll call yields a single scroll event.
+
+        Regression test for an issue where Windows ``Controller._scroll``
+        fired ``on_scroll`` twice: once via ``NotifierMixin._emit`` and once
+        via the ``WH_MOUSE_LL`` hook that already receives ``SendInput``
+        events.
+        """
+        events = []
+        listener = self.listener(
+            on_scroll=lambda x, y, dx, dy: events.append((dx, dy)))
+        with listener:
+            time.sleep(0.2)
+            del events[:]
+            self.controller.scroll(0, 1)
+            time.sleep(0.5)
+
+        self.assertEqual(
+            1, len(events),
+            'Expected exactly one scroll event, got %d: %r' % (
+                len(events), events))


### PR DESCRIPTION
## Summary

Adds a regression test for #672. Asserts that `Controller.scroll(0, 1)` produces exactly one `on_scroll` callback within a 0.5s window — not two — and is intended to land alongside the fix on this branch.

## Verification

Run on Windows 11 (Python 3.13) against three pynput sources:

| Source | Result |
|---|---|
| `pynput==1.8.1` (PyPI) | `AssertionError: 1 != 2 ... got 2: [(0, 1), (0, 1)]` |
| `master` (`a871765`) | same — fails (2 events) |
| this branch (with fix) | passes (1 event) |

```
$ python -m unittest tests.mouse_controller_tests.MouseControllerTest.test_scroll_no_duplicate -v
test_scroll_no_duplicate ... ok
Ran 1 test in 4.711s
OK
```

The test reuses existing test infrastructure (`self.listener`, `self.controller`) and is platform-agnostic — it should also pass on macOS/Xorg where the bug never existed.