### PR TITLE
Invalidate the macOS event tap on listener stop

### DIFF
--- a/lib/pynput/_util/darwin.py
+++ b/lib/pynput/_util/darwin.py
@@ -30,12 +30,13 @@ import six
 import objc
 import HIServices
 
-from CoreFoundation import CFRelease
+from CoreFoundation import CFMachPortInvalidate, CFRelease
 
 from Quartz import (
     CFMachPortCreateRunLoopSource,
     CFRunLoopAddSource,
     CFRunLoopGetCurrent,
+    CFRunLoopRemoveSource,
     CFRunLoopRunInMode,
     CFRunLoopStop,
     CGEventGetIntegerValueField,
@@ -221,6 +222,8 @@ class ListenerMixin(object):
             )
 
         self._loop = None
+        tap = None
+        loop_source = None
         try:
             tap = self._create_event_tap()
             if tap is None:
@@ -252,6 +255,33 @@ class ListenerMixin(object):
             # pylint: enable=W0702
 
         finally:
+            # Each cleanup step is guarded independently: as in the loop
+            # above, these calls may fail during teardown of the virtual
+            # machine, and a step failing during teardown must not prevent
+            # the tap from being invalidated below
+            try:
+                if loop_source is not None and self._loop is not None:
+                    CFRunLoopRemoveSource(
+                        self._loop, loop_source, kCFRunLoopDefaultMode
+                    )
+            except AttributeError:
+                pass
+            try:
+                if tap is not None:
+                    CGEventTapEnable(tap, False)
+            except AttributeError:
+                pass
+            try:
+                if tap is not None:
+                    # CoreGraphics retains the CFMachPort returned by
+                    # CGEventTapCreate, so dropping our reference never
+                    # deallocates it; without an explicit invalidate, the
+                    # window server keeps the (disabled) event tap
+                    # registration until the process exits, leaking one
+                    # registration per listener stop
+                    CFMachPortInvalidate(tap)
+            except AttributeError:
+                pass
             self._loop = None
 
     def _stop_platform(self):

--- a/lib/pynput/_util/darwin.py
+++ b/lib/pynput/_util/darwin.py
@@ -260,15 +260,15 @@ class ListenerMixin(object):
             # machine, and a step failing during teardown must not prevent
             # the tap from being invalidated below
             try:
+                if tap is not None:
+                    CGEventTapEnable(tap, False)
+            except AttributeError:
+                pass
+            try:
                 if loop_source is not None and self._loop is not None:
                     CFRunLoopRemoveSource(
                         self._loop, loop_source, kCFRunLoopDefaultMode
                     )
-            except AttributeError:
-                pass
-            try:
-                if tap is not None:
-                    CGEventTapEnable(tap, False)
             except AttributeError:
                 pass
             try:


### PR DESCRIPTION
This PR fixes a macOS resource leak: **every `Listener` start/stop cycle (whose event tap was successfully created) leaks one window-server event-tap registration**, which survives until the process exits. Programs that cycle listeners (hotkey recorders, pause/resume capture flows, restart loops, test suites) accumulate stale registrations — and large accumulations demonstrably degrade input responsiveness **system-wide** (shown with a synthetic 1,000-registration repro and video in the Karabiner-Elements PR linked below, and maintainer-confirmed in Easydict after the identical leak reached ~1,400 registrations).

## Mechanism

`Listener._run` (in `lib/pynput/_util/darwin.py`) creates the tap as a local variable; `_stop_platform` only stops the run loop, and the `finally` block just clears `self._loop`. When `_run` returns, the pyobjc `CFMachPortRef` proxy is garbage-collected, which only `CFRelease`s it. But CoreGraphics holds internal references to the `CFMachPort` returned by `CGEventTapCreate` (observed retain count 4 immediately after creation), so releasing the client reference never deallocates it — the window server keeps the (disabled) event-tap registration until the process exits. The only correct disposal is an explicit `CFMachPortInvalidate`.

The same bug class was recently root-caused across several projects: fixes have been submitted to Karabiner-Elements ([pqrs-org/Karabiner-Elements#4505](https://github.com/pqrs-org/Karabiner-Elements/pull/4505) — includes a video of the system-wide symptom) and Mos ([Caldis/Mos#999](https://github.com/Caldis/Mos/pull/999)), and Easydict found and fixed the identical leak independently ([tisfeng/Easydict#1170](https://github.com/tisfeng/Easydict/issues/1170), maintainer-confirmed).

## The fix

In `_run`'s `finally`: remove the run-loop source, disable the tap, and `CFMachPortInvalidate` it (with `tap`/`loop_source` initialized before the `try` so the early-return path stays safe, and each step guarded independently to match the file's interpreter-teardown tolerance). No behavior change while the listener runs. The teardown deliberately mirrors the setup in reverse (add source → enable ⇒ disable → remove source → invalidate); strictly the invalidate alone would suffice — invalidating a `CFMachPort` also invalidates its derived run-loop source — but the explicit sequence keeps the pairing with the setup obvious.

## Verification (red/green on macOS 26.5, Apple Silicon)

Script counting this process's own entries in the window server's tap table around three listener start/stop cycles:

```python
import os
import sys
import time

import Quartz
from pynput import keyboard


def own_tap_count():
    err, taps, count = Quartz.CGGetEventTapList(1024, None, None)
    if err != 0:
        raise RuntimeError(f"CGGetEventTapList failed: {err}")
    pid = os.getpid()
    return sum(1 for t in (taps or []) if t.tappingProcess == pid)


baseline = own_tap_count()
print(f"baseline own taps: {baseline}")
for i in range(3):
    listener = keyboard.Listener(on_press=lambda k: None)
    listener.start()
    listener.wait()
    if not listener.IS_TRUSTED:
        sys.exit("process is not trusted for input monitoring; without a "
                 "tap the leak cannot be observed (false green)")
    time.sleep(0.3)
    listener.stop()
    listener.join()
    time.sleep(0.2)
    print(f"after listener cycle {i + 1}: {own_tap_count()}")

leaked = own_tap_count() - baseline
print(f"leaked: {leaked}")
sys.exit(1 if leaked > 0 else 0)
```

Released pynput 1.8.2:

```
baseline own taps: 0
after listener cycle 1: 1
after listener cycle 2: 2
after listener cycle 3: 3
leaked: 3
```

With this patch:

```
baseline own taps: 0
after listener cycle 1: 0
after listener cycle 2: 0
after listener cycle 3: 0
leaked: 0
```

**Disclosure:** this analysis and patch were prepared with AI assistance (Claude); all measurements are from a real machine and the final diff was human-reviewed. I should also say up front that I have little experience with the pynput codebase itself — this change largely mirrors the fix we applied for the same leak in Karabiner-Elements and Mos (linked above), and the fix Easydict's maintainer applied independently for their instance of it, adapted to pynput's listener lifecycle and teardown conventions. Happy to adjust to project preferences.
