### PR TITLE
Call self._mark_ready() in uinput backend's _run, matching xorg and win32

### DIFF
--- a/lib/pynput/_util/uinput.py
+++ b/lib/pynput/_util/uinput.py
@@ -53,6 +53,7 @@ class ListenerMixin(object):
             self._dev.grab()
 
     def _run(self):
+        self._mark_ready()
         for event in self._dev.read_loop():
             if event.type in self._EVENTS:
                 self._handle_message(event)


### PR DESCRIPTION
Fixes #685.

The uinput backend's _run never called self._mark_ready() before entering the read loop, so listener.wait() and with listener: block forever, xorg.py and win32.py both call it right before their blocking event loop starts, this just brings uinput in line with that.

No test added, the uinput backend needs an actual /dev/uinput device, and there's no existing test coverage for it at all in the repo to extend.